### PR TITLE
Bug:Change AlbumArtist + custom metadata

### DIFF
--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1044,13 +1044,13 @@ class Song extends database_object implements media, library_item
             $catalog = Catalog::create_from_id($this->catalog);
             if ($catalog->get_type() == 'local') {
                 debug_event('song', 'Writing id3 metadata to file ' . $this->file, 5);
-                $meta = $this->get_metadata();
                 if (self::isCustomMetadataEnabled()) {
                     foreach ($this->getMetadata() as $metadata) {
                         $meta[$metadata->getField()->getName()] = $metadata->getData();
                     }
                 }
-                $id3 = new vainfo($this->file);
+                $meta = $this->get_metadata();
+                $id3  = new vainfo($this->file);
                 $id3->write_id3($meta);
                 Catalog::update_media_from_tags($this);
             }


### PR DESCRIPTION
I changed the order in which the Metadata is parsed in write_id3. This will set custom fields to values of song-instance as they are defined in get_metadata, overriding them as needed. Otherwise the standard metadata like "band" will be overridden by custom value in each song that cannot be changed from edit album. So changing Albumartist wouldn't work.