### PR TITLE
Bug:Moving Song to new Album + writing of Tags

### DIFF
--- a/lib/class/song.class.php
+++ b/lib/class/song.class.php
@@ -1029,6 +1029,7 @@ class Song extends database_object implements media, library_item
             } // end whitelist
         } // end foreach
 
+        $this->format();
         $this->write_id3();
 
         return $this->id;


### PR DESCRIPTION
There is a Bug preventing moving Songs to another album when Tag writing is enabled: As update-functions will only set db-ids to new value and will not change full qualifier names in metatags before writing, the id3 tags will still be written with old names. When reading Tags afterwards, the changes are discarded. Added format() in between update of db.ids and writing prevents this.