### PR TITLE
Illegal String Offset in edit.server.php

### DIFF
--- a/server/edit.server.php
+++ b/server/edit.server.php
@@ -140,7 +140,7 @@ switch ($_REQUEST['action']) {
         $libitem->format();
 
         xoutput_headers();
-        $results['id'] = $new_id;
+        $results = array('id' => $new_id);
         echo xoutput_from_array($results);
         exit;
     default:


### PR DESCRIPTION
This fixes the error-message [Runtime Error] Illegal string offset 'id' in file /srv/www/htdocs/ampache/server/edit.server.php(143) showing up in log.